### PR TITLE
Add intercept in RoomChannel example

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -194,7 +194,8 @@ We handle incoming events with `handle_in/3`. We can pattern match on the event 
 ```elixir
 defmodule HelloPhoenix.RoomChannel do
   use Phoenix.Channel
-
+  intercept ["new_msg"]
+  
   def join("rooms:lobby", auth_msg, socket) do
     {:ok, socket}
   end


### PR DESCRIPTION
`handle_out` is never called in the example without `intercept ["new_msg"]`
